### PR TITLE
Create basic CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,55 @@
+name: Continuous Integration
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+    branches:
+      - master
+  push:
+    branches:
+      - master
+    tags:
+      - '**'
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  build-run-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository contents
+        uses: actions/checkout@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Build binary
+        run: |
+          docker build  --tag lustre_exporter:binary -f docker/Dockerfile .
+      - name: Build rpm
+        run: |
+          docker build -t lustre_exporter:rpm -f docker/RPM-Dockerfile .
+
+      - name: Extract binary
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          docker run --rm -v $PWD:/cpy lustre_exporter:binary
+          sudo chown -R $USER:$GROUP build
+      - name: Upload binary
+        uses: actions/upload-artifact@v1.0.0
+        if: startsWith(github.ref, 'refs/tags/v')
+        with:
+          name: lustre-exporter Binary ${{ github.ref_name }}
+          path: build/
+      - name: Extract rpm
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          sudo rm -rf build
+          docker run --rm -v $PWD:/rpm lustre_exporter:rpm
+          sudo chown -R $USER:$GROUP build
+      - name: Upload RPM
+        uses: actions/upload-artifact@v1.0.0
+        if: startsWith(github.ref, 'refs/tags/v')
+        with:
+          name: lustre-exporter RPM ${{ github.ref_name }}
+          path: build/

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 <!-- TODO: Create an issue for both, if necessary.
 [![Go Report Card](https://goreportcard.com/badge/github.com/HewlettPackard/lustre_exporter)](https://goreportcard.com/report/github.com/HewlettPackard/lustre_exporter)
-[![Build Status](https://travis-ci.org/HewlettPackard/lustre_exporter.svg?branch=master)](https://travis-ci.org/HewlettPackard/lustre_exporter)
 -->
+[![Continuous Integration](https://github.com/GSI-HPC/lustre_exporter/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/GSI-HPC/lustre_exporter/actions/workflows/ci.yml)
 
 [Prometheus](https://prometheus.io/) exporter for [Lustre](https://www.lustre.org/) metrics.
 


### PR DESCRIPTION
This PR creates a basic CI. I have host where I neither want to run docker nor build on the host so I build a pipeline which uploads the results so that they can be fetched and I thought I share this.
This CI only uploads the files as artifacts but it could be easily changed to use Packages or even Releases. If you're interested let me know.