### PR TITLE
fix job_id regex to remove quotes

### DIFF
--- a/sources/proc_common.go
+++ b/sources/proc_common.go
@@ -36,7 +36,7 @@ const (
 
 var (
 	numRegexPattern      = regexp.MustCompile(`[0-9]*\.[0-9]+|[0-9]+`)
-	jobidRegexPattern    = regexp.MustCompile(`(?m:job_id: *([\d\w\-_.:+/() ]*)$)`)
+	jobidRegexPattern    = regexp.MustCompile(`(?m:job_id: *"?([\d\w\-_.:+/() ]*)"?$)`)
 	jobStatsRegexPattern = regexp.MustCompile(`(?ms:job_id:.*?$.*?(?:-|\z))`)
 )
 


### PR DESCRIPTION
This should fix issue #46 by removing optional quotation marks in the job_id regex.