### PR TITLE
fix: Use MDT and MGS enabled values properly

### DIFF
--- a/sources/sysfs.go
+++ b/sources/sysfs.go
@@ -159,10 +159,10 @@ func newLustreSysFsSource() LustreSource {
 		l.generateOSTMetricTemplates(OstEnabled)
 	}
 	if MgsEnabled != disabled {
-		l.generateMGSMetricTemplates(OstEnabled)
+		l.generateMGSMetricTemplates(MgsEnabled)
 	}
 	if MdtEnabled != disabled {
-		l.generateMDTMetricTemplates(OstEnabled)
+		l.generateMDTMetricTemplates(MdtEnabled)
 	}
 	return &l
 }


### PR DESCRIPTION
I just noticed this while looking around a bit.

I hope, it's the right thing?