### PR TITLE
refactor: newLustreProcMetric now accepts *lustreHelpStruct

### DIFF
--- a/sources/proc_common.go
+++ b/sources/proc_common.go
@@ -69,15 +69,15 @@ type lustreHelpStruct struct {
 	priorityLevel   string
 }
 
-func newLustreProcMetric(filename string, promName string, source string, path string, helpText string, hasMultipleVals bool, metricFunc prometheusType) *lustreProcMetric {
+func newLustreProcMetric(item *lustreHelpStruct, source string, path string) *lustreProcMetric {
 	return &lustreProcMetric{
-		filename:        filename,
-		promName:        promName,
+		filename:        item.filename,
+		promName:        item.promName,
 		source:          source,
 		path:            path,
-		helpText:        helpText,
-		hasMultipleVals: hasMultipleVals,
-		metricFunc:      metricFunc,
+		helpText:        item.helpText,
+		hasMultipleVals: item.hasMultipleVals,
+		metricFunc:      item.metricFunc,
 	}
 }
 

--- a/sources/procfs.go
+++ b/sources/procfs.go
@@ -160,7 +160,7 @@ func (s *lustreProcFsSource) generateOSTMetricTemplates(filter string) {
 	for path := range metricMap {
 		for _, item := range metricMap[path] {
 			if filter == extended || item.priorityLevel == core {
-				newMetric := newLustreProcMetric(item.filename, item.promName, "ost", path, item.helpText, item.hasMultipleVals, item.metricFunc)
+				newMetric := newLustreProcMetric(&item, "ost", path)
 				s.lustreProcMetrics = append(s.lustreProcMetrics, *newMetric)
 			}
 		}
@@ -186,7 +186,7 @@ func (s *lustreProcFsSource) generateMDTMetricTemplates(filter string) {
 	for path := range metricMap {
 		for _, item := range metricMap[path] {
 			if filter == extended || item.priorityLevel == core {
-				newMetric := newLustreProcMetric(item.filename, item.promName, "mdt", path, item.helpText, item.hasMultipleVals, item.metricFunc)
+				newMetric := newLustreProcMetric(&item, "mdt", path)
 				s.lustreProcMetrics = append(s.lustreProcMetrics, *newMetric)
 			}
 		}
@@ -207,7 +207,7 @@ func (s *lustreProcFsSource) generateMGSMetricTemplates(filter string) {
 	for path := range metricMap {
 		for _, item := range metricMap[path] {
 			if filter == extended || item.priorityLevel == core {
-				newMetric := newLustreProcMetric(item.filename, item.promName, "mgs", path, item.helpText, item.hasMultipleVals, item.metricFunc)
+				newMetric := newLustreProcMetric(&item, "mgs", path)
 				s.lustreProcMetrics = append(s.lustreProcMetrics, *newMetric)
 			}
 		}
@@ -219,7 +219,7 @@ func (s *lustreProcFsSource) generateMDSMetricTemplates(filter string) {
 	for path := range metricMap {
 		for _, item := range metricMap[path] {
 			if filter == extended || item.priorityLevel == core {
-				newMetric := newLustreProcMetric(item.filename, item.promName, "mds", path, item.helpText, item.hasMultipleVals, item.metricFunc)
+				newMetric := newLustreProcMetric(&item, "mds", path)
 				s.lustreProcMetrics = append(s.lustreProcMetrics, *newMetric)
 			}
 		}
@@ -267,7 +267,7 @@ func (s *lustreProcFsSource) generateClientMetricTemplates(filter string) {
 	for path := range metricMap {
 		for _, item := range metricMap[path] {
 			if filter == extended || item.priorityLevel == core {
-				newMetric := newLustreProcMetric(item.filename, item.promName, "client", path, item.helpText, item.hasMultipleVals, item.metricFunc)
+				newMetric := newLustreProcMetric(&item, "client", path)
 				s.lustreProcMetrics = append(s.lustreProcMetrics, *newMetric)
 			}
 		}
@@ -297,7 +297,7 @@ func (s *lustreProcFsSource) generateGenericMetricTemplates(filter string) {
 	for path := range metricMap {
 		for _, item := range metricMap[path] {
 			if filter == extended || item.priorityLevel == core {
-				newMetric := newLustreProcMetric(item.filename, item.promName, "generic", path, item.helpText, item.hasMultipleVals, item.metricFunc)
+				newMetric := newLustreProcMetric(&item, "generic", path)
 				s.lustreProcMetrics = append(s.lustreProcMetrics, *newMetric)
 			}
 		}

--- a/sources/sys.go
+++ b/sources/sys.go
@@ -83,7 +83,7 @@ func (s *lustreSysSource) generateLNETTemplates(filter string) {
 	for path := range metricMap {
 		for _, item := range metricMap[path] {
 			if filter == extended || item.priorityLevel == core {
-				newMetric := newLustreProcMetric(item.filename, item.promName, "lnet", path, item.helpText, item.hasMultipleVals, item.metricFunc)
+				newMetric := newLustreProcMetric(&item, "lnet", path)
 				s.lustreProcMetrics = append(s.lustreProcMetrics, *newMetric)
 			}
 		}

--- a/sources/sysfs.go
+++ b/sources/sysfs.go
@@ -51,7 +51,7 @@ func (s *LustreSysFsSource) generateHealthStatusTemplates(filter string) {
 	for path := range metricMap {
 		for _, item := range metricMap[path] {
 			if filter == extended || item.priorityLevel == core {
-				newMetric := newLustreProcMetric(item.filename, item.promName, "health", path, item.helpText, item.hasMultipleVals, item.metricFunc)
+				newMetric := newLustreProcMetric(&item, "health", path)
 				s.lustreProcMetrics = append(s.lustreProcMetrics, *newMetric)
 			}
 		}
@@ -95,7 +95,7 @@ func (s *LustreSysFsSource) generateOSTMetricTemplates(filter string) {
 	for path := range metricMap {
 		for _, item := range metricMap[path] {
 			if filter == extended || item.priorityLevel == core {
-				newMetric := newLustreProcMetric(item.filename, item.promName, "ost", path, item.helpText, item.hasMultipleVals, item.metricFunc)
+				newMetric := newLustreProcMetric(&item, "ost", path)
 				s.lustreProcMetrics = append(s.lustreProcMetrics, *newMetric)
 			}
 		}
@@ -116,7 +116,7 @@ func (s *LustreSysFsSource) generateMGSMetricTemplates(filter string) {
 	for path := range metricMap {
 		for _, item := range metricMap[path] {
 			if filter == extended || item.priorityLevel == core {
-				newMetric := newLustreProcMetric(item.filename, item.promName, "mgs", path, item.helpText, item.hasMultipleVals, item.metricFunc)
+				newMetric := newLustreProcMetric(&item, "mgs", path)
 				s.lustreProcMetrics = append(s.lustreProcMetrics, *newMetric)
 			}
 		}
@@ -142,7 +142,7 @@ func (s *LustreSysFsSource) generateMDTMetricTemplates(filter string) {
 	for path := range metricMap {
 		for _, item := range metricMap[path] {
 			if filter == extended || item.priorityLevel == core {
-				newMetric := newLustreProcMetric(item.filename, item.promName, "mdt", path, item.helpText, item.hasMultipleVals, item.metricFunc)
+				newMetric := newLustreProcMetric(&item, "mdt", path)
 				s.lustreProcMetrics = append(s.lustreProcMetrics, *newMetric)
 			}
 		}


### PR DESCRIPTION
Instead of unpacking all fields of lustreHelpStruct at every call site, pass a pointer to the struct directly.